### PR TITLE
fix case when lb already deleted

### DIFF
--- a/internal/service/lb/manager.go
+++ b/internal/service/lb/manager.go
@@ -84,6 +84,10 @@ func (s *Manager) DeleteLB(ctx context.Context, labelSelector string) error {
 	if err != nil {
 		return utils.IgnoreNotFound(err)
 	}
+	if len(lbs) == 0 {
+		// consider as already deleted
+		return nil
+	}
 	if len(lbs) > 1 {
 		return fmt.Errorf("found more than one lb with same label")
 	}


### PR DESCRIPTION
API don't return 404 error when no resource was found, so need to check len of lbs separately.